### PR TITLE
Add Amazon SQS helper module

### DIFF
--- a/src/BridgeFunctionApp/AwsSqsModule.fs
+++ b/src/BridgeFunctionApp/AwsSqsModule.fs
@@ -1,4 +1,31 @@
 module AwsSqsModule
 
-// Placeholder for AWS SQS helper functions.
-// Real implementation would wrap AmazonSQSClient operations.
+open System
+open System.Threading.Tasks
+open Amazon
+open Amazon.SQS
+open Amazon.SQS.Model
+
+/// Create an Amazon SQS client from credentials and region information.
+let createClient (accessKey:string) (secretKey:string) (region:RegionEndpoint) : IAmazonSQS =
+    AmazonSQSClient(accessKey, secretKey, region) :> IAmazonSQS
+
+/// Receive a batch of messages from the given queue.
+let receiveMessages (client: IAmazonSQS) (queueUrl:string) (maxMessages:int) (visibilityTimeout:int)
+    : Task<ReceiveMessageResponse> =
+    let req =
+        ReceiveMessageRequest(
+            QueueUrl = queueUrl,
+            MaxNumberOfMessages = maxMessages,
+            WaitTimeSeconds = 0,
+            VisibilityTimeout = visibilityTimeout)
+    client.ReceiveMessageAsync(req)
+
+/// Delete a message from the queue using its receipt handle.
+let deleteMessage (client: IAmazonSQS) (queueUrl:string) (receiptHandle:string)
+    : Task<DeleteMessageResponse> =
+    client.DeleteMessageAsync(queueUrl, receiptHandle)
+
+/// Dispose the client when no longer needed.
+let dispose (client: IAmazonSQS) =
+    (client :> IDisposable).Dispose()


### PR DESCRIPTION
## Summary
- implement `AwsSqsModule` with helpers for creating and using an Amazon SQS client

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c4ff21ae0832eb44d97a04711c05c