### PR TITLE
Refactor QueueBridge to use helpers

### DIFF
--- a/src/BridgeFunctionApp/QueueBridge.fs
+++ b/src/BridgeFunctionApp/QueueBridge.fs
@@ -5,9 +5,8 @@ open Microsoft.Azure.Functions.Worker
 open System.Threading.Tasks
 open Microsoft.Extensions.Logging
 open Amazon
-open Amazon.SQS
-open Amazon.SQS.Model
-open Azure.Storage.Queues
+open AwsSqsModule
+open AzureQueueModule
 
 [<Function("SqsToAzureBridge")>]
 let run
@@ -29,30 +28,25 @@ let run
         log.LogError("Missing configuration — aborting.")
     else
 
-    // 2. Create clients (outside hot path scope when converting to DI)
+    // 2. Create clients via helper modules
     let region  = RegionEndpoint.GetBySystemName(regionName)
-    use sqs     = new AmazonSQSClient(accessKey, secretAccessKey, region)
-    let aopts   = QueueClientOptions(MessageEncoding = QueueMessageEncoding.Base64)
-    let aqueue  = QueueClient(azureConn, azureQueueName, aopts)
-    aqueue.CreateIfNotExists()
+    use sqs     = AwsSqsModule.createClient accessKey secretAccessKey region
+    let aqueue  = AzureQueueModule.getClient azureConn azureQueueName
+    do! AzureQueueModule.createIfNotExists aqueue
 
     // 3. Pull batch from SQS
-    let r = ReceiveMessageRequest(QueueUrl = queueUrl,
-                                  MaxNumberOfMessages = 10,
-                                  WaitTimeSeconds = 0,
-                                  VisibilityTimeout = 180)
-
     task {
-        let! resp = sqs.ReceiveMessageAsync(r)
+        let! resp = AwsSqsModule.receiveMessages sqs queueUrl 10 180
         let messages = resp.Messages
         log.LogInformation("Fetched {Count} msg(s) from SQS.", messages.Count)
 
         for m in messages do
             try
-                do! aqueue.SendMessageAsync m.Body
-                do! sqs.DeleteMessageAsync(queueUrl, m.ReceiptHandle)
+                do! AzureQueueModule.sendMessage aqueue m.Body
+                do! AwsSqsModule.deleteMessage sqs queueUrl m.ReceiptHandle
                 log.LogInformation("Moved message {Id}.", m.MessageId)
             with ex ->
                 log.LogError(ex, "Failed to move msg {Id}", m.MessageId)
     }
-    |> Task.WaitAll
+    |> Async.AwaitTask
+    |> Async.RunSynchronously


### PR DESCRIPTION
## Summary
- call `AwsSqsModule` and `AzureQueueModule` functions in the timer function
- rely on helper modules to create and cache clients

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c5ab02ee0832eb28517aa27e1717d